### PR TITLE
Make the Hammer Whack togglable via a define rather than commenting it out + fix Miracle Amy crash

### DIFF
--- a/SonicMania/Game.h
+++ b/SonicMania/Game.h
@@ -75,6 +75,9 @@
 #define MANIA_USE_PLUS (GAME_VERSION >= VER_105)
 #define MANIA_USE_EGS  (GAME_VERSION == VER_107)
 
+#ifndef ESA_ENABLE_HAMMERWHACK
+#define ESA_ENABLE_HAMMERWHACK (MANIA_USE_PLUS && 0)
+#endif
 // -------------------------
 // GAME LOGIC
 // -------------------------

--- a/SonicMania/Objects/Global/Ring.c
+++ b/SonicMania/Objects/Global/Ring.c
@@ -98,6 +98,7 @@ void Ring_Create(void *data)
 void Ring_StageLoad(void)
 {
     Ring->aniFrames = RSDK.LoadSpriteAnimation("Global/Ring.bin", SCOPE_STAGE);
+    Ring->amyFrames = RSDK.LoadSpriteAnimation("Global/MiracleSparkles.bin", SCOPE_STAGE);
 
     Ring->hitbox.left   = -8;
     Ring->hitbox.top    = -8;

--- a/SonicMania/Objects/Global/SuperSparkle.c
+++ b/SonicMania/Objects/Global/SuperSparkle.c
@@ -40,7 +40,7 @@ void SuperSparkle_Update(void)
             self->timer = 0;
         }
 
-        if (player->characterID == ID_SONIC && !(Zone->timer & 7)) {
+        if ((player->characterID == ID_SONIC || player->characterID == ID_AMY) && !(Zone->timer & 7)) {
             int32 x = player->position.x + RSDK.Rand(-TO_FIXED(12), TO_FIXED(12));
             int32 y = player->position.y + RSDK.Rand(-TO_FIXED(18), TO_FIXED(18));
 
@@ -51,31 +51,12 @@ void SuperSparkle_Update(void)
             sparkle->visible    = false;
             sparkle->velocity.y = -TO_FIXED(1);
             sparkle->drawGroup  = player->drawGroup;
-            RSDK.SetSpriteAnimation(Ring->aniFrames, Zone->timer % 3 + 2, &sparkle->animator, true, 0);
+            if (player->characterID == ID_AMY)
+                RSDK.SetSpriteAnimation(Ring->amyFrames, Zone->timer % 3, &sparkle->animator, true, 0);
+            else
+                RSDK.SetSpriteAnimation(Ring->aniFrames, Zone->timer % 3 + 2, &sparkle->animator, true, 0);
             int32 cnt = sparkle->animator.frameCount;
-            if (sparkle->animator.animationID == 2) {
-                sparkle->alpha = 0xE0;
-                cnt >>= 1;
-            }
-            sparkle->maxFrameCount  = cnt - 1;
-            sparkle->animator.speed = RSDK.Rand(6, 8);
-        }
-
-        if (player->characterID == ID_AMY && !(Zone->timer & 7)) {
-            int32 x = player->position.x + RSDK.Rand(-TO_FIXED(12), TO_FIXED(12));
-            int32 y = player->position.y + RSDK.Rand(-TO_FIXED(18), TO_FIXED(18));
-            Ring->amyFrames = RSDK.LoadSpriteAnimation("Global/MiracleSparkles.bin", SCOPE_STAGE);
-
-            EntityRing *sparkle = CREATE_ENTITY(Ring, NULL, x, y);
-            sparkle->state      = Ring_State_Sparkle;
-            sparkle->stateDraw  = Ring_Draw_Sparkle;
-            sparkle->active     = ACTIVE_NORMAL;
-            sparkle->visible    = false;
-            sparkle->velocity.y = -TO_FIXED(1);
-            sparkle->drawGroup  = player->drawGroup;
-            RSDK.SetSpriteAnimation(Ring->amyFrames, Zone->timer % 3, &sparkle->animator, true, 0);
-            int32 cnt = sparkle->animator.frameCount;
-            if (sparkle->animator.animationID == 2) {
+            if (sparkle->animator.animationID == (player->characterID == ID_AMY ? 0 : 2)) {
                 sparkle->alpha = 0xE0;
                 cnt >>= 1;
             }


### PR DESCRIPTION
This PR uncomments the code for the removed Hammer Whack move and instead creates a define for it, allowing the user to edit a single line to enable the move when compiling. The code for the Hammer Whack itself was also edited to make it _slightly_ more polished and usable (though still not enough to call it good).

This also fixes a possible crash when turning into Miracle Amy that was happening due to the sprites for the sparkles not being initialized properly.